### PR TITLE
Updated api-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.gradle/
 *.iml
 *.iws
 target/

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
         exclude group: 'com.sk89q.worldguard', module: 'worldguard-legacy'
         exclude group: 'net.milkbowl.vault', module: 'Vault'
     }
-    implementation 'org.spigotmc:spigot-api:1.16.4-R0.1-SNAPSHOT'
+    implementation 'org.spigotmc:spigot-api:1.13-R0.1-SNAPSHOT'
     implementation 'org.jetbrains:annotations:20.1.0'
     compile 'club.minnced:discord-webhooks:0.5.5-rc'
     compile('com.github.dv8fromtheworld:jda:5951675') {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,6 @@
 name: DiSky
 version: 1.11
+api-version: 1.13
 main: info.itsthesky.DiSky.DiSky
 author: ItsTheSky
 description: Skript addon which allows you to interact with Discord through Skript.


### PR DESCRIPTION
A 1.8+ plugin should use 1.13 for the Spigot API